### PR TITLE
fix(): deplacement des joueurs

### DIFF
--- a/src/js/grid.js
+++ b/src/js/grid.js
@@ -38,8 +38,8 @@ class Grid {
     movePlayer(td) {
         console.log("movePlayer", td);
         //1. récupérer (x,y) de la case td
-        const x = td.dataset.x;
-        const y = td.dataset.y;
+        const x = parseInt(td.dataset.x);
+        const y = parseInt(td.dataset.y);
         console.log(x,y);
         //2. attribuer les nouvelles coordonnées au player actif
         this.players[this.activePlayerIndex].x = x;
@@ -218,8 +218,8 @@ class Grid {
     }
 
     getMovableCells() {
-        const x = this.players[this.activePlayerIndex].x;
-        const y = this.players[this.activePlayerIndex].y;
+        const x = parseInt(this.players[this.activePlayerIndex].x);
+        const y = parseInt(this.players[this.activePlayerIndex].y);
         const cells = [];
         // déplacement à droite
         for (let i = x+1; i < x+4; i++) {


### PR DESCRIPTION
Bug lors du déplacement des joueurs. Au 2eme tour, seules les cases en haut et à gauche étaient "movable"
La raison était que les nouvelles coordonnées des joueurs se transformaient en string après le premier déplacement. Du coup les conditions de boucles en plus n'étaient plus vérifiées (ex: "3" + 1 = "31") car considérées comme concaténation. Les conditions en "-" restaient valables (ex: "3" - 1 = 2)